### PR TITLE
Switch to Fedora 38

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ This repository contains resources concerning unofficial Linux distribution aime
 
 The repo currently contains Kickstart files to create a live media image with accessible environment. This image can be later used to install the system on a device. It contains kickstart files to build the distro with English or Czech language selected.
 
-The live media is currently based on Fedora 37.
+The live media is currently based on Fedora 38.
 
 ## Building live media ISO
 
@@ -12,7 +12,7 @@ The kickstart file is inspired by the Fedora Mate spin. The Mate environment is 
 
 Kickstart documentation can be found at <https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html>.
 
-Building of this image requires Fedora. It is strongly recommended to use Fedora version matching the one you are going to build. So if you are going to build a live media based on Fedora 37, it is strongly recommended to do it from Fedora 37 environment.
+Building of this image requires Fedora. It is strongly recommended to use Fedora version matching the one you are going to build. So if you are going to build a live media based on Fedora 38, it is strongly recommended to do it from Fedora 38 environment.
 
 So how to build it?
 
@@ -30,7 +30,7 @@ So how to build it?
 
     - this makes sure that all includes will be handled correctly
 
-5. sudo livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --iso-name vojtux_37.iso --project vojtux --releasever 37 --ks <output_kickstart_file.ks> --tmp live/tmp
+5. sudo livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --iso-name vojtux_38.iso --project vojtux --releasever 38 --ks <output_kickstart_file.ks> --tmp live/tmp
 
     - --make-iso creates ISO image. Note that you can create multiple things with livemedia-creator.
 
@@ -40,11 +40,11 @@ So how to build it?
 
     - --anaconda-arg="--noselinux" disables selinux during the installation, it was causing problems.
 
-    - --iso-name vojtux_37.iso provides name for the resulting ISO image
+    - --iso-name vojtux_38.iso provides name for the resulting ISO image
 
     - --project vojtux project name, this is used as image label and it is visible in the boot menu
 
-    - --releasever 37 this is also visible in the boot menu
+    - --releasever 38 this is also visible in the boot menu
 
     - --ks <output_kickstart_file.ks> use the kickstart file created in previous steps
 
@@ -52,7 +52,7 @@ So how to build it?
 
 ## What is actually done?
 
-The result will be stored in the tmp directory in a folder with randomly generated name. In this folder there will be "images" folder and in this folder there will be a file called according to the --iso-name parameter. The live image is based on Fedora 37 Mate spin.
+The result will be stored in the tmp directory in a folder with randomly generated name. In this folder there will be a file called according to the --iso-name parameter. The live image is based on Fedora 38 Mate spin.
 
 Following additional changes are applied:
 

--- a/ks/fedora-live-base.ks
+++ b/ks/fedora-live-base.ks
@@ -10,7 +10,6 @@
 lang en_US.UTF-8
 keyboard us
 timezone US/Eastern
-selinux --enforcing
 firewall --enabled --service=mdns
 xconfig --startxonboot
 zerombr
@@ -21,7 +20,7 @@ network --bootproto=dhcp --device=link --activate
 rootpw --lock --iscrypted locked
 shutdown
 
-%include fedora-repo.ks
+
 
 %packages
 # Explicitly specified here:
@@ -29,12 +28,6 @@ shutdown
 kernel
 kernel-modules
 kernel-modules-extra
-
-# This was added a while ago, I think it falls into the category of
-# "Diagnosis/recovery tool useful from a Live OS image".  Leaving this untouched
-# for now.
-#memtest86+
-@x86-baremetal-tools # memtest86+ is included
 
 # The point of a live image is to install
 anaconda

--- a/ks/fedora-live-base.ks
+++ b/ks/fedora-live-base.ks
@@ -7,34 +7,23 @@
 # Does includes "default" language configuration (kickstarts including
 # this template can override these settings)
 
-#lang en_US.UTF-8
-#keyboard us
-#timezone US/Eastern
-authselect --useshadow --passalgo=sha512
+lang en_US.UTF-8
+keyboard us
+timezone US/Eastern
 selinux --enforcing
 firewall --enabled --service=mdns
 xconfig --startxonboot
 zerombr
 clearpart --all
+part / --size 5120 --fstype ext4
 services --enabled=NetworkManager,ModemManager --disabled=sshd
 network --bootproto=dhcp --device=link --activate
 rootpw --lock --iscrypted locked
 shutdown
 
-%include repos.ks
+%include fedora-repo.ks
 
 %packages
-@base-x
-@guest-desktop-agents
-@standard
-@core
-@fonts
-@input-methods
-@dial-up
-@multimedia
-@hardware-support
-@printing
-
 # Explicitly specified here:
 # <notting> walters: because otherwise dependency loops cause yum issues.
 kernel
@@ -44,20 +33,25 @@ kernel-modules-extra
 # This was added a while ago, I think it falls into the category of
 # "Diagnosis/recovery tool useful from a Live OS image".  Leaving this untouched
 # for now.
-memtest86+
+#memtest86+
+@x86-baremetal-tools # memtest86+ is included
 
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
 anaconda-live
 @anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-device-mapper-multipath
 
 # Need aajohan-comfortaa-fonts for the SVG rnotes images
 aajohan-comfortaa-fonts
 
 # Without this, initramfs generation during live image creation fails: #1242586
 dracut-live
-syslinux
+# syslinux is in @x86-baremetal-tools
 
 # anaconda needs the locales available to run for different locales
 glibc-all-langpacks
@@ -106,13 +100,7 @@ for arg in \`cat /proc/cmdline\` ; do
   fi
 done
 
-# enable swaps unless requested otherwise
-swaps=\`blkid -t TYPE=swap -o device\`
-if ! strstr "\`cat /proc/cmdline\`" noswap && [ -n "\$swaps" ] ; then
-  for s in \$swaps ; do
-    action "Enabling swap partition \$s" swapon \$s
-  done
-fi
+# enable swapfile if it exists
 if ! strstr "\`cat /proc/cmdline\`" noswap && [ -f /run/initramfs/live/\${livedir}/swap.img ] ; then
   action "Enabling swap file" swapon /run/initramfs/live/\${livedir}/swap.img
 fi
@@ -199,9 +187,6 @@ systemctl --no-reload disable mdmonitor-takeover.service 2> /dev/null || :
 systemctl stop mdmonitor.service 2> /dev/null || :
 systemctl stop mdmonitor-takeover.service 2> /dev/null || :
 
-# don't enable the gnome-settings-daemon packagekit plugin
-gsettings set org.gnome.software download-updates 'false' || :
-
 # don't start cron/at as they tend to spawn things which are
 # disk intensive that are painful on a live image
 systemctl --no-reload disable crond.service 2> /dev/null || :
@@ -223,7 +208,7 @@ touch /.liveimg-configured
 # https://bugzilla.redhat.com/show_bug.cgi?id=679486
 # the hostname must be something else than 'localhost'
 # https://bugzilla.redhat.com/show_bug.cgi?id=1370222
-echo "localhost-live" > /etc/hostname
+hostnamectl set-hostname "localhost-live"
 
 EOF
 
@@ -303,11 +288,8 @@ EOF
 
 # work around for poor key import UI in PackageKit
 rm -f /var/lib/rpm/__db*
-releasever=$(rpm -q --qf '%{version}\n' --whatprovides system-release)
-basearch=$(uname -i)
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
 echo "Packages within this LiveCD"
-rpm -qa
+rpm -qa --qf '%{size}\t%{name}-%{version}-%{release}.%{arch}\n' |sort -rn
 # Note that running rpm recreates the rpm db files which aren't needed or wanted
 rm -f /var/lib/rpm/__db*
 
@@ -342,23 +324,15 @@ touch /etc/machine-id
 
 
 %post --nochroot
-cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
+# For livecd-creator builds only (lorax/livemedia-creator handles this directly)
+if [ -n "$LIVE_ROOT" ]; then
+    cp "$INSTALL_ROOT"/usr/share/licenses/*-release-common/* "$LIVE_ROOT/"
 
-# only works on x86, x86_64
-if [ "$(uname -i)" = "i386" -o "$(uname -i)" = "x86_64" ]; then
-    # For livecd-creator builds
-    if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
-    cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
-
-    # For lorax/livemedia-creator builds
-    sed -i '
-    /## make boot.iso/ i\
-    # Add livecd-iso-to-disk script to .iso filesystem at /LiveOS/\
-    <% f = "usr/bin/livecd-iso-to-disk" %>\
-    %if exists(f):\
-        install ${f} ${LIVEDIR}/${f|basename}\
-    %endif\
-    ' /usr/share/lorax/templates.d/99-generic/live/x86.tmpl
+    # only installed on x86, x86_64
+    if [ -f /usr/bin/livecd-iso-to-disk ]; then
+        mkdir -p "$LIVE_ROOT/LiveOS"
+        cp /usr/bin/livecd-iso-to-disk "$LIVE_ROOT/LiveOS"
+    fi
 fi
 
 %end

--- a/ks/repos.ks
+++ b/ks/repos.ks
@@ -1,11 +1,11 @@
 # add repositories as sources of packages
-repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-37&arch=x86_64
-repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f37&arch=x86_64
-url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-37&arch=x86_64
+repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-38&arch=x86_64
+repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f38&arch=x86_64
+url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-38&arch=x86_64
 #rpm fusion repos
-repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-37&arch=x86_64
-repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-37&arch=x86_64
-repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-37&arch=$basearch
-repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-37&arch=$basearch
+repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-38&arch=x86_64
+repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-38&arch=x86_64
+repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-38&arch=$basearch
+repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-38&arch=$basearch
 #vojtux repo
-repo --install --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-37-x86_64/
+repo --install --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-38-x86_64/

--- a/ks/repos.ks
+++ b/ks/repos.ks
@@ -8,4 +8,4 @@ repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mi
 repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-38&arch=$basearch
 repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-38&arch=$basearch
 #vojtux repo
-repo --install --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-38-x86_64/
+repo --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-38-x86_64/

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -1,4 +1,5 @@
 %include fedora-live-base.ks
+%include repos.ks
 
 selinux --disabled
 

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -77,7 +77,6 @@ mate-menu
 #hardware support
 @hardware-support
 gutenprint-cups
-cups-bjnp
 cups-filters
 foomatic-db
 foomatic-db-ppds

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -182,6 +182,10 @@ rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-*-primary
 echo "Importing RPM Fusion keys"
 rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-*-primary
 
+# import Vojtux-apps key
+dnf copr enable -y tyrylu/vojtux-apps
+
+
 #installing ocrdesktop
 #git clone https://github.com/chrys87/ocrdesktop.git /opt/ocrdesktop
 #chmod -R 755 /opt/ocrdesktop


### PR DESCRIPTION
Change repos to Fedora 38. Also ensure that we have correct configuration of vojtux-apps repo.
Also the fedora-live-base.ks has been updated from the Fedora 38 package.
Lastly, the documentation was updated to show 38.