### PR TITLE
Switch to Fedora 41

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,19 +31,32 @@ So if you are going to build a live media based on Fedora 41, it is strongly rec
 
 So how to build it?
 
-1. sudo dnf install lorax-lmc-novirt
+1. Install prerequisites.
+
+    ```bash
+    sudo dnf install lorax-lmc-novirt
+    ```
 
 2. clone this repo
 
+    ```bash
+    git clone https://github.com/vojtapolasek/vojtux
+    cd vojtux
+    ```
+
 3. create a directory structure to store cache and tmp files (optional)
 
-    - mkdir -p live/tmp
+    ```bash
+    mkdir -p live/tmp
+    ```
 
-4. ksflatten -c <input_kickstart_file.ks> -o <output_kickstart_file.ks>
+4. Create the final kickstart file, blending several kickstarts together.
 
-    - choose ks/vojtux_cs.ks or ks/vojtux_en.ks as an input file, based on your language choice
+    ```bash
+    ksflatten -c ks/vojtux_en.ks -o vojtux.ks
+    ```
 
-    - this makes sure that all includes will be handled correctly
+5. Build the image
 
     ```bash
     sudo livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --iso-name vojtux_41.iso --project vojtux --releasever 41 --ks <output_kickstart_file.ks> --tmp live/tmp
@@ -63,7 +76,7 @@ So how to build it?
 
     - --releasever 41 this is also visible in the boot menu
 
-    - --ks <output_kickstart_file.ks> use the kickstart file created in previous steps
+    - --ks vojtux.ks use the kickstart file created in previous steps
 
     - --tmp live/tmp optional argument if you want to use your own defined tmp directory
 

--- a/Readme.md
+++ b/Readme.md
@@ -17,13 +17,11 @@ The live media is currently based on Fedora 41.
 *Warning!* The Czech kickstart file is outdated!
 
 This repository is currently transitioning from the state where customizations were present in the kickstart file to a state where most of customizations will be packaged as RPMs.
-
 This is currently implemented for the English kickstart file, Czech kickstart file is not maintained right now.
-
 In future, it will get updated or deleted entirely.
 
-
-The kickstart file is inspired by the Fedora Mate spin. The Mate environment is chosen because it is lightweight and its accessibility is prety good.
+The kickstart file is inspired by the Fedora Mate spin.
+The Mate environment is chosen because it is lightweight and its accessibility is prety good.
 
 Kickstart documentation can be found at <https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html>.
 
@@ -88,7 +86,8 @@ Your `vojtux_38.iso` should be listed as above.
 
 ## What is actually done?
 
-The result will be stored in the tmp directory in a folder with randomly generated name. In this folder there will be a file called according to the --iso-name parameter. The live image is based on Fedora 38 Mate spin.
+The result will be stored in the tmp directory in a folder with randomly generated name.
+In this folder there will be a file called according to the --iso-name parameter.
 
 Following additional changes are applied:
 

--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,8 @@ So how to build it?
 
 ## Docker build
 
+**Note: currently not maintained, will be updated soon.**
+
 There is a simple build.sh script included to show the sequence that I used to build the image.
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,16 @@
 # What is it about?
 
-This repository contains resources concerning unofficial Linux distribution aimed at visually impaired users. This distribution is called Vojtux. It is based on first name of the main contributor; Vojtech.
+This repository contains resources concerning unofficial Linux distribution aimed at visually impaired users.
+This distribution is called Vojtux.
+The name is based on first name of the main contributor; Vojtech.
 
-The repo currently contains Kickstart files to create a live media image with accessible environment. This image can be later used to install the system on a device. It contains kickstart files to build the distro with English or Czech language selected.
+The repo currently contains Kickstart files to create a live media image with accessible environment.
+This image can be later used to install the system on a device.
+The repo contains kickstart files to build the live image with English language.
+It also contains  files which are used to build RPM packages which are not part of Fedora and they are used in this distro.
+Resulting RPM packages are present in the [Vojtux Copr repository](https://copr.fedorainfracloud.org/coprs/tyrylu/vojtux-apps/).
 
-The live media is currently based on Fedora 38.
+The live media is currently based on Fedora 41.
 
 ## Building live media ISO
 
@@ -21,7 +27,9 @@ The kickstart file is inspired by the Fedora Mate spin. The Mate environment is 
 
 Kickstart documentation can be found at <https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html>.
 
-Building of this image requires Fedora. It is strongly recommended to use Fedora version matching the one you are going to build. So if you are going to build a live media based on Fedora 38, it is strongly recommended to do it from Fedora 38 environment.
+Building of this image requires Fedora.
+It is strongly recommended to use Fedora version matching the one you are going to build.
+So if you are going to build a live media based on Fedora 41, it is strongly recommended to do it from Fedora 41 environment.
 
 So how to build it?
 
@@ -39,7 +47,9 @@ So how to build it?
 
     - this makes sure that all includes will be handled correctly
 
-5. sudo livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --iso-name vojtux_38.iso --project vojtux --releasever 38 --ks <output_kickstart_file.ks> --tmp live/tmp
+    ```bash
+    sudo livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --iso-name vojtux_41.iso --project vojtux --releasever 41 --ks <output_kickstart_file.ks> --tmp live/tmp
+    ```
 
     - --make-iso creates ISO image. Note that you can create multiple things with livemedia-creator.
 
@@ -49,11 +59,11 @@ So how to build it?
 
     - --anaconda-arg="--noselinux" disables selinux during the installation, it was causing problems.
 
-    - --iso-name vojtux_38.iso provides name for the resulting ISO image
+    - --iso-name vojtux_41.iso provides name for the resulting ISO image
 
     - --project vojtux project name, this is used as image label and it is visible in the boot menu
 
-    - --releasever 38 this is also visible in the boot menu
+    - --releasever 41 this is also visible in the boot menu
 
     - --ks <output_kickstart_file.ks> use the kickstart file created in previous steps
 

--- a/Readme.md
+++ b/Readme.md
@@ -108,13 +108,7 @@ Following additional changes are applied:
 
 - added RPM Fusion free and nonfree package repositories
 
-- added custom repository with Festival Czech voices and one specific for this distro so that we can push updates
-
-- in case of Czech version:
-
-    - system locale is set to Czech, keyboard to Czech qwertz, Czech and Slovak language packs are downloaded
-
-    - the time zone is set to Europe/Prague
+- added vojtux-apps repository specific for Vojtux distro so that it is easier to push updates
 
 - Orca screenreader starts at login screen and also after login for current and also newly created users
 
@@ -122,7 +116,7 @@ Following additional changes are applied:
 
 - QT accessibility is enabled
 
-- accessibility of applications run with sudo is enabled
+- accessibility of applications launched with sudo is enabled
 
 - Grub tune is added, although it does not work in every case
 
@@ -136,11 +130,9 @@ Following additional changes are applied:
 
 - file associations are modified so that audio files open in VLC
 
-- Festival is enabled with Czech voice, however it behaves strangely on physical hardware
-
 - /etc/systemd/system.conf is modified to speed up shutdown
 
-- Selinux policiy is set to permissive
+- Selinux policy is set to permissive
 
 - Slick greeter is replaced with Lightdm GTK greeter because of problems with Orca not starting after login
 
@@ -150,7 +142,7 @@ Following additional changes are applied:
 
     - gimagereader QT version
 
-    - pidgin with support for Facebook and Skype Web
+    - pidgin with support for Facebook
 
     - Xsane
 
@@ -169,8 +161,6 @@ Following additional changes are applied:
     - Git, Curl, Wget, Sed
 
     - VLC player
-
-    - Qt-at-spi
 
     - Tmux to enhance working with consoles
 
@@ -220,5 +210,5 @@ Following additional changes are applied:
 
 - Alt-Super-l start the LIOS software
 
-- ALT-Super-m - vypnutí / zapnutí monitoru
+- Alt-Super-m - vypnutí / zapnutí monitoru
 

--- a/ks/fedora-live-base.ks
+++ b/ks/fedora-live-base.ks
@@ -14,7 +14,6 @@ firewall --enabled --service=mdns
 xconfig --startxonboot
 zerombr
 clearpart --all
-part / --size 5120 --fstype ext4
 services --enabled=NetworkManager,ModemManager --disabled=sshd
 network --bootproto=dhcp --device=link --activate
 rootpw --lock --iscrypted locked

--- a/ks/repos.ks
+++ b/ks/repos.ks
@@ -1,11 +1,11 @@
 # add repositories as sources of packages
-repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-38&arch=x86_64
-repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f38&arch=x86_64
-url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-38&arch=x86_64
+repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-41&arch=x86_64
+repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f41&arch=x86_64
+url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-41&arch=x86_64
 #rpm fusion repos
-repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-38&arch=x86_64
-repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-38&arch=x86_64
-repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-38&arch=$basearch
-repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-38&arch=$basearch
+repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-41&arch=x86_64
+repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-41&arch=x86_64
+repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-41&arch=$basearch
+repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-41&arch=$basearch
 #vojtux repo
-repo --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-38-x86_64/
+repo --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-41-x86_64/

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -15,6 +15,7 @@ part / --size 10240 --fstype ext4
 -nfs-utils
 -NetworkManager-openvpn-gnome
 @mate
+@desktop-accessibility
 compiz
 compiz-plugins-main
 compiz-plugins-extra

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -70,8 +70,6 @@ nss-mdns
 #additional software for Agora
 pidgin
 purple-facebook
-purple-skypeweb
-pidgin-skypeweb
 xsane
 chromium
 mate-menu
@@ -96,7 +94,6 @@ git
 curl
 vlc
 sed
-qt-at-spi
 wget
 jmtpfs
 nano

--- a/ks/vojtux_en.ks
+++ b/ks/vojtux_en.ks
@@ -8,14 +8,6 @@ timezone US/Eastern
 
 %packages
 tesseract-langpack-eng
-festvox-awb-arctic-hts
-festvox-bdl-arctic-hts
-festvox-clb-arctic-hts
-festvox-jmk-arctic-hts
-festvox-kal-diphone
-festvox-rab-diphone
-festvox-rms-arctic-hts
-festvox-slt-arctic-hts
 hunspell-en
 vojtux-docs-en
 %end


### PR DESCRIPTION
See commits for more details.

But in general, kickstarts were switched to use Fedora 41.

I built an ISO image from the successfully, it boots, screen reader is started automatically. It is not thoroughly tested yet, but it will be tested as soon as the test plan is created and published.

Also note that Czech version is really not maintained now and the question is if it will be. Do not use it.

Also the Docker script is not updated yet, I will do it later.

Readme has been updated to reflect all changes done in the transition to Fedora 41.

Changes worth mentioning are:

- remove Festival packages and customizations entirely; the project is not being developed and I think the future lies in RHVoice
- removed packages no longer existing in Fedora 41, mainly qt-at-spi and Pidgin support for Skype web