### PR TITLE
remove / add packages to the live image

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,8 +136,6 @@ Following additional changes are applied:
 
 - extra packages are preinstalled
 
-    - gimagereader QT version
-
     - pidgin with support for Facebook
 
     - Xsane
@@ -148,7 +146,7 @@ Following additional changes are applied:
 
     - Soundconverter
 
-    - Tesseract OCR engine with English, Czech and Slovak data
+    - Tesseract OCR engine with English data
 
     - Ifuse for support of Apple storage
 
@@ -162,22 +160,13 @@ Following additional changes are applied:
 
     - Chromium
 
-- Following packages were removed:
-
-    - Exaile
-
-    - Hexchat
-
-    - Filezilla
-
-    - Gnote
+    - ocrmypdf (command line version only)
 
 - there is a special script which ensures that the sound at the login screen is not muted and is at 50% of volume
 
 - a script for toggling physical monitor is added, functionality not tested
 
 - a sound theme is added, [source](https://github.com/coffeeking/Linux-a11y-sound-theme)
-
 
 ## Added shortcuts
 

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -55,7 +55,7 @@ rp-pppoe
 
 #customizations for Vojtux
 
-#additional software for Agora
+#additional software for Vojtux
 pidgin
 purple-facebook
 xsane
@@ -80,7 +80,7 @@ soundconverter
 ifuse
 git
 curl
-vlc
+@vlc
 sed
 wget
 jmtpfs
@@ -96,11 +96,7 @@ timidity++
 lightdm-gtk-greeter
 lightdm-gtk-greeter-settings
 #ocr
-g++
-python3-devel
-tesseract-devel
 lios
-
 toggle-monitor
 
 # settings and shortcuts

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -12,8 +12,6 @@ services --enabled="chronyd,brltty"
 part / --size 10240 --fstype ext4
 
 %packages
--nfs-utils
--NetworkManager-openvpn-gnome
 @mate
 @desktop-accessibility
 compiz
@@ -35,18 +33,11 @@ fusion-icon
 caja-actions
 mate-disk-usage-analyzer
 
-# blacklist applications which breaks mate-desktop
--audacious
-
 # office
 @libreoffice
 
 # dsl tools
 rp-pppoe
-
-# FIXME; apparently the glibc maintainers dislike this, but it got put into the
-# desktop image at some point.  We won't touch this one for now.
-nss-mdns
 
 # Drop things for size
 -@3d-printing
@@ -56,17 +47,13 @@ nss-mdns
 -gnome-software
 -gnome-user-docs
 
--@mate-applications
 -mate-icon-theme-faenza
 
 # Help and art can be big, too
 -gnome-user-docs
 -evolution-help
 
-#customizations for Agora
-#removing inaccessible packages
--filezilla
--exaile
+#customizations for Vojtux
 
 #additional software for Agora
 pidgin

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -104,6 +104,7 @@ vojtux-settings
 sox
 # OCR desktop
 ocrdesktop
+ocrmypdf
 
 # a11y sound theme
 a11y-sound-theme


### PR DESCRIPTION
See commits for more information.
But in general, there were some packages removed (probably copied from the original Mate desktop kickstart file) and I did not see a reason for that anymore.
I also added ocrmypdf package.