### PR TITLE
remove hack from the past

### DIFF
--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -182,8 +182,7 @@ dconf update
 
 #configure speech dispatcher
 sed -i 's/#AddModule "espeak-ng"                "sd_espeak-ng" "espeak-ng.conf"/AddModule "espeak-ng"                "sd_espeak-ng" "espeak-ng.conf"/' /etc/speech-dispatcher/speechd.conf
-# prevent long delay when shutting down
-echo "DefaultTimeoutStopSec=10s" >> /etc/systemd/system.conf
+
 #setup lightdm
 # create a wrapper script which makes sure that sound is unmuted and at 50% on login screen
 cat > /usr/local/bin/orca-login-wrapper <<EOM


### PR DESCRIPTION
In the past, for some reason the live system took very long time to shutdown on my physical testing hardware.
That's why this hack has been introduced.
Now I tested it in VM and on my laptop and it seems it is not needed.