### PR TITLE
reduce settings of Mate which are overridden

### DIFF
--- a/rpm/vojtux-settings/02-panel
+++ b/rpm/vojtux-settings/02-panel
@@ -1,57 +1,3 @@
-[org/mate/panel/general]
-object-id-list=['menu-bar', 'terminal', 'web-browser', 'email-client', 'volume-control', 'notification-area', 'show-desktop', 'window-list', 'object-0']
-toplevel-id-list=['top']
-
-[org/mate/panel/objects/clock]
-applet-iid='ClockAppletFactory::ClockApplet'
-locked=true
-object-type='applet'
-panel-right-stick=true
-position=0
-toplevel-id='top'
-
-[org/mate/panel/objects/email-client]
-launcher-location='/usr/share/applications/mozilla-thunderbird.desktop'
-locked=true
-object-type='launcher'
-position=40
-toplevel-id='top'
-
-[org/mate/panel/objects/file-browser]
-launcher-location='/usr/share/applications/caja-browser.desktop'
-locked=true
-object-type='launcher'
-position=10
-toplevel-id='top'
-
-[org/mate/panel/objects/menu-bar]
-locked=true
-object-type='menu-bar'
-position=0
-toplevel-id='top'
-
-[org/mate/panel/objects/notification-area]
-applet-iid='NotificationAreaAppletFactory::NotificationArea'
-locked=true
-object-type='applet'
-panel-right-stick=true
-position=10
-toplevel-id='top'
-
-[org/mate/panel/objects/terminal]
-launcher-location='/usr/share/applications/mate-terminal.desktop'
-locked=true
-object-type='launcher'
-position=20
-toplevel-id='top'
-
-[org/mate/panel/objects/web-browser]
-launcher-location='/usr/share/applications/firefox.desktop'
-locked=true
-object-type='launcher'
-position=30
-toplevel-id='top'
-
 # advanced mate menu
 [org/mate/panel/objects/object-0]
 applet-iid='MateMenuAppletFactory::MateMenuApplet'
@@ -59,40 +5,6 @@ object-type='applet'
 panel-right-stick=false
 position=-1
 toplevel-id='top'
-
-
-[org/gnome/desktop/wm/keybindings]
-begin-move=@as []
-begin-resize=@as []
-close=['<Alt>F4']
-lower=@as []
-maximize=@as []
-maximize-horizontally=@as []
-maximize-vertically=@as []
-move-to-monitor-left=['<Super>Left']
-move-to-monitor-right=['<Super>Right']
-move-to-workspace-1=['<Shift><Alt>F1']
-move-to-workspace-2=['<Shift><Alt>F2']
-move-to-workspace-3=['<Shift><Alt>F3']
-move-to-workspace-4=['<Shift><Alt>F4']
-move-to-workspace-down=['<Primary><Super>Down', '<Control><Shift><Alt>Down']
-move-to-workspace-left=['<Primary><Super>Left']
-move-to-workspace-right=['<Primary><Super>Right']
-move-to-workspace-up=['<Primary><Super>Up', '<Control><Shift><Alt>Up']
-raise=@as []
-raise-or-lower=@as []
-show-desktop=['<Super>d']
-switch-applications=['', '<Alt>Tab']
-switch-group=['<Super>Tab', '<Alt>Above_Tab']
-switch-to-workspace-down=['<Primary><Alt>Down', '<Control><Alt>Down']
-switch-to-workspace-left=['<Primary><Alt>Left']
-switch-to-workspace-right=['<Primary><Alt>Right']
-switch-to-workspace-up=['<Primary><Alt>Up', '<Control><Alt>Up']
-switch-windows=['<Alt>Tab']
-toggle-maximized=@as []
-toggle-on-all-workspaces=@as []
-toggle-shaded=@as []
-unmaximize=@as []
 
 #preventing sound previews in Caja
 [org/mate/caja/preferences]

--- a/rpm/vojtux-settings/vojtux-settings.spec
+++ b/rpm/vojtux-settings/vojtux-settings.spec
@@ -1,6 +1,6 @@
 Name:     vojtux-settings
 Version:  1
-Release:  3%{?dist}
+Release:  4%{?dist}
 Summary:  Settings for Vojtux
 License:  Public Domain
 
@@ -33,13 +33,16 @@ dconf update
 %{_sysconfdir}/dconf/db/distro.d/03-keybindings
 
 %changelog
+* Fri Apr 04 2025 vojtapolasek <krecoun@gmail.com> - 1-4
+- remove most of Mate panel settings overrides, overriding only minimal set of settings
+
 * Fri Dec 20 2024 Vojtech Polasek <vpolasek@redhat.com> - 1-3
 - change entry names not to occupy names reserved for user-created keyboard shortcuts
 - remove lios keyboard shortcut
 - update keybindings related to audio volume to use wpctl
 
 * Mon Sep 18 2023 Vojtech Polasek <vpolasek@redhat.com> - 1-2
-- update dconf database in the %post phase
+- update dconf database in the post phase
 - install files into distro.d directory as we are a package
 - update dconf database after package removal
 


### PR DESCRIPTION
We were overriding many Mate panel settings. This maybe was useful in the past, but the accessibility possibly improved.
Let's limit the set to minimum and rather report bugs upstream.