### PR TITLE
advanced-mate-menu: do not package the configuration

### DIFF
--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -177,6 +177,19 @@ rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-nonfree-fedora-*-primary
 # import Vojtux-apps key
 dnf copr enable -y tyrylu/vojtux-apps
 
+echo "Preparing Mate panel configuration override..."
+cat > /etc/dconf/db/local.d/00-panel-live-user <<- EOM
+[org/mate/panel/general]
+object-id-list=['menu-bar', 'terminal', 'web-browser', 'email-client', 'volume-control', 'notification-area', 'show-desktop', 'window-list', 'advanced-mate-menu']
+toplevel-id-list=['top']
+
+[org/mate/panel/objects/advanced-mate-menu]
+applet-iid='MateMenuAppletFactory::MateMenuApplet'
+object-type='applet'
+panel-right-stick=false
+position=-1
+toplevel-id='top'
+EOM
 echo "Updating dconf databases..."
 dconf update
 

--- a/rpm/vojtux-settings/02-panel
+++ b/rpm/vojtux-settings/02-panel
@@ -1,11 +1,3 @@
-# advanced mate menu
-[org/mate/panel/objects/object-0]
-applet-iid='MateMenuAppletFactory::MateMenuApplet'
-object-type='applet'
-panel-right-stick=false
-position=-1
-toplevel-id='top'
-
 #preventing sound previews in Caja
 [org/mate/caja/preferences]
 preview-sound='never'

--- a/rpm/vojtux-settings/vojtux-settings.spec
+++ b/rpm/vojtux-settings/vojtux-settings.spec
@@ -1,6 +1,6 @@
 Name:     vojtux-settings
 Version:  1
-Release:  4%{?dist}
+Release:  5%{?dist}
 Summary:  Settings for Vojtux
 License:  Public Domain
 
@@ -33,6 +33,9 @@ dconf update
 %{_sysconfdir}/dconf/db/distro.d/03-keybindings
 
 %changelog
+* Thu Apr 17 2025 vojtapolasek <krecoun@gmail.com> - 1-5
+- remove mate-menu configuration completely, it is impossible to package this. It will be preconfigured only at the live media.
+
 * Fri Apr 04 2025 vojtapolasek <krecoun@gmail.com> - 1-4
 - remove most of Mate panel settings overrides, overriding only minimal set of settings
 


### PR DESCRIPTION
The reason is that if we would like to package the configuration as a installable package, we would need to consider the case when someone installs the package on a system with existing user Mate configuration. I do not think that it is possible to append dconf configuration of Mate panel to existing one. therefore, there is a chance we would broke someone's existing Mat panel configuration. Let's solve this rather with documentation.