### PR TITLE
add whole definition of mate panel applets to kickstart

### DIFF
--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -180,8 +180,52 @@ dnf copr enable -y tyrylu/vojtux-apps
 echo "Preparing Mate panel configuration override..."
 cat > /etc/dconf/db/local.d/00-panel-live-user <<- EOM
 [org/mate/panel/general]
-object-id-list=['menu-bar', 'terminal', 'web-browser', 'email-client', 'volume-control', 'notification-area', 'show-desktop', 'window-list', 'advanced-mate-menu']
+object-id-list=['clock', 'menu-bar', 'volume-control', 'notification-area', 'show-desktop', 'window-list', 'advanced-mate-menu']
 toplevel-id-list=['top']
+
+[org/mate/panel/objects/show-desktop]
+applet-iid='WnckletFactory::ShowDesktopApplet'
+locked=true
+object-type='applet'
+position=0
+toplevel-id='bottom'
+
+[org/mate/panel/objects/window-list]
+applet-iid='WnckletFactory::WindowListApplet'
+locked=true
+object-type='applet'
+position=20
+toplevel-id='bottom'
+
+[org/mate/panel/objects/clock]
+applet-iid='ClockAppletFactory::ClockApplet'
+locked=true
+object-type='applet'
+panel-right-stick=true
+position=0
+toplevel-id='top'
+
+[org/mate/panel/objects/menu-bar]
+locked=true
+object-type='menu-bar'
+position=0
+toplevel-id='top'
+
+[org/mate/panel/objects/notification-area]
+applet-iid='NotificationAreaAppletFactory::NotificationArea'
+locked=true
+object-type='applet'
+panel-right-stick=true
+position=10
+toplevel-id='top'
+
+[org/mate/panel/objects/volume-control]
+applet-iid='GvcAppletFactory::GvcApplet'
+locked=true
+object-type='applet'
+panel-right-stick=true
+position=20
+toplevel-id='top'
 
 [org/mate/panel/objects/advanced-mate-menu]
 applet-iid='MateMenuAppletFactory::MateMenuApplet'


### PR DESCRIPTION
Without this, it does not work and only the advanced-mate-menu was there (see previous commit)