### PR TITLE
enable sshd on the live image because of tests

### DIFF
--- a/ks/fedora-live-base.ks
+++ b/ks/fedora-live-base.ks
@@ -14,7 +14,7 @@ firewall --enabled --service=mdns
 xconfig --startxonboot
 zerombr
 clearpart --all
-services --enabled=NetworkManager,ModemManager --disabled=sshd
+services --enabled=NetworkManager,ModemManager
 network --bootproto=dhcp --device=link --activate
 rootpw --lock --iscrypted locked
 shutdown

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -7,7 +7,7 @@ selinux --disabled
 group --name brlapi
 
 # System services
-services --enabled="chronyd,brltty"
+services --enabled="chronyd,brltty,sshd"
 
 part / --size 10240 --fstype ext4
 


### PR DESCRIPTION
Tests need to access the running live image through SSH.