### PR TITLE
Revert "enable sshd on the live image because of tests"

### DIFF
--- a/ks/fedora-live-base.ks
+++ b/ks/fedora-live-base.ks
@@ -14,7 +14,7 @@ firewall --enabled --service=mdns
 xconfig --startxonboot
 zerombr
 clearpart --all
-services --enabled=NetworkManager,ModemManager
+services --enabled=NetworkManager,ModemManager --disabled=sshd
 network --bootproto=dhcp --device=link --activate
 rootpw --lock --iscrypted locked
 shutdown

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -7,7 +7,7 @@ selinux --disabled
 group --name brlapi
 
 # System services
-services --enabled="chronyd,brltty,sshd"
+services --enabled="chronyd,brltty"
 
 part / --size 10240 --fstype ext4
 


### PR DESCRIPTION
Reverts vojtapolasek/vojtux#92

It was decided not to enable sshd on default live image because it could introduce security problems.
passwordless sshd will be enabled only in testing environment.