### PR TITLE
Base Vojtux on Fedora 42

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ The repo contains kickstart files to build the live image with English language.
 It also contains  files which are used to build RPM packages which are not part of Fedora and they are used in this distro.
 Resulting RPM packages are present in the [Vojtux Copr repository](https://copr.fedorainfracloud.org/coprs/tyrylu/vojtux-apps/).
 
-The live media is currently based on Fedora 41.
+The live media is currently based on Fedora 42.
 
 ## Building live media ISO
 
@@ -27,7 +27,7 @@ Kickstart documentation can be found at <https://pykickstart.readthedocs.io/en/l
 
 Building of this image requires Fedora.
 It is strongly recommended to use Fedora version matching the one you are going to build.
-So if you are going to build a live media based on Fedora 41, it is strongly recommended to do it from Fedora 41 environment.
+So if you are going to build a live media based on Fedora 42, it is strongly recommended to do it from Fedora 42 environment.
 
 So how to build it?
 
@@ -59,7 +59,7 @@ So how to build it?
 5. Build the image
 
     ```bash
-    sudo livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --iso-name vojtux_41.iso --project vojtux --releasever 41 --ks <output_kickstart_file.ks> --tmp live/tmp
+    sudo livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --iso-name vojtux_42.iso --project vojtux --releasever 42 --ks <output_kickstart_file.ks> --tmp live/tmp
     ```
 
     - --make-iso creates ISO image. Note that you can create multiple things with livemedia-creator.
@@ -70,11 +70,11 @@ So how to build it?
 
     - --anaconda-arg="--noselinux" disables selinux during the installation, it was causing problems.
 
-    - --iso-name vojtux_41.iso provides name for the resulting ISO image
+    - --iso-name vojtux_42.iso provides name for the resulting ISO image
 
     - --project vojtux project name, this is used as image label and it is visible in the boot menu
 
-    - --releasever 41 this is also visible in the boot menu
+    - --releasever 42 this is also visible in the boot menu
 
     - --ks vojtux.ks use the kickstart file created in previous steps
 

--- a/ks/fedora-live-base.ks
+++ b/ks/fedora-live-base.ks
@@ -19,8 +19,6 @@ network --bootproto=dhcp --device=link --activate
 rootpw --lock --iscrypted locked
 shutdown
 
-%include fedora-repo.ks
-
 %packages
 # Explicitly specified here:
 # <notting> walters: because otherwise dependency loops cause yum issues.

--- a/ks/fedora-live-base.ks
+++ b/ks/fedora-live-base.ks
@@ -19,7 +19,7 @@ network --bootproto=dhcp --device=link --activate
 rootpw --lock --iscrypted locked
 shutdown
 
-
+%include fedora-repo.ks
 
 %packages
 # Explicitly specified here:
@@ -37,236 +37,25 @@ anaconda-live
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
 -fcoe-utils
 -device-mapper-multipath
+-sdubby
 
 # Need aajohan-comfortaa-fonts for the SVG rnotes images
 aajohan-comfortaa-fonts
 
 # Without this, initramfs generation during live image creation fails: #1242586
 dracut-live
-# syslinux is in @x86-baremetal-tools
 
 # anaconda needs the locales available to run for different locales
 glibc-all-langpacks
 
-# no longer in @core since 2018-10, but needed for livesys script
-initscripts
-chkconfig
+# provide the livesys scripts
+livesys-scripts
 %end
 
 %post
-# FIXME: it'd be better to get this installed from a package
-cat > /etc/rc.d/init.d/livesys << EOF
-#!/bin/bash
-#
-# live: Init script for live image
-#
-# chkconfig: 345 00 99
-# description: Init script for live image.
-### BEGIN INIT INFO
-# X-Start-Before: display-manager chronyd
-### END INIT INFO
-
-. /etc/init.d/functions
-
-if ! strstr "\`cat /proc/cmdline\`" rd.live.image || [ "\$1" != "start" ]; then
-    exit 0
-fi
-
-if [ -e /.liveimg-configured ] ; then
-    configdone=1
-fi
-
-exists() {
-    which \$1 >/dev/null 2>&1 || return
-    \$*
-}
-
-livedir="LiveOS"
-for arg in \`cat /proc/cmdline\` ; do
-  if [ "\${arg##rd.live.dir=}" != "\${arg}" ]; then
-    livedir=\${arg##rd.live.dir=}
-    continue
-  fi
-  if [ "\${arg##live_dir=}" != "\${arg}" ]; then
-    livedir=\${arg##live_dir=}
-  fi
-done
-
-# enable swapfile if it exists
-if ! strstr "\`cat /proc/cmdline\`" noswap && [ -f /run/initramfs/live/\${livedir}/swap.img ] ; then
-  action "Enabling swap file" swapon /run/initramfs/live/\${livedir}/swap.img
-fi
-
-mountPersistentHome() {
-  # support label/uuid
-  if [ "\${homedev##LABEL=}" != "\${homedev}" -o "\${homedev##UUID=}" != "\${homedev}" ]; then
-    homedev=\`/sbin/blkid -o device -t "\$homedev"\`
-  fi
-
-  # if we're given a file rather than a blockdev, loopback it
-  if [ "\${homedev##mtd}" != "\${homedev}" ]; then
-    # mtd devs don't have a block device but get magic-mounted with -t jffs2
-    mountopts="-t jffs2"
-  elif [ ! -b "\$homedev" ]; then
-    loopdev=\`losetup -f\`
-    if [ "\${homedev##/run/initramfs/live}" != "\${homedev}" ]; then
-      action "Remounting live store r/w" mount -o remount,rw /run/initramfs/live
-    fi
-    losetup \$loopdev \$homedev
-    homedev=\$loopdev
-  fi
-
-  # if it's encrypted, we need to unlock it
-  if [ "\$(/sbin/blkid -s TYPE -o value \$homedev 2>/dev/null)" = "crypto_LUKS" ]; then
-    echo
-    echo "Setting up encrypted /home device"
-    plymouth ask-for-password --command="cryptsetup luksOpen \$homedev EncHome"
-    homedev=/dev/mapper/EncHome
-  fi
-
-  # and finally do the mount
-  mount \$mountopts \$homedev /home
-  # if we have /home under what's passed for persistent home, then
-  # we should make that the real /home.  useful for mtd device on olpc
-  if [ -d /home/home ]; then mount --bind /home/home /home ; fi
-  [ -x /sbin/restorecon ] && /sbin/restorecon /home
-  if [ -d /home/liveuser ]; then USERADDARGS="-M" ; fi
-}
-
-findPersistentHome() {
-  for arg in \`cat /proc/cmdline\` ; do
-    if [ "\${arg##persistenthome=}" != "\${arg}" ]; then
-      homedev=\${arg##persistenthome=}
-    fi
-  done
-}
-
-if strstr "\`cat /proc/cmdline\`" persistenthome= ; then
-  findPersistentHome
-elif [ -e /run/initramfs/live/\${livedir}/home.img ]; then
-  homedev=/run/initramfs/live/\${livedir}/home.img
-fi
-
-# if we have a persistent /home, then we want to go ahead and mount it
-if ! strstr "\`cat /proc/cmdline\`" nopersistenthome && [ -n "\$homedev" ] ; then
-  action "Mounting persistent /home" mountPersistentHome
-fi
-
-if [ -n "\$configdone" ]; then
-  exit 0
-fi
-
-# add liveuser user with no passwd
-action "Adding live user" useradd \$USERADDARGS -c "Live System User" liveuser
-passwd -d liveuser > /dev/null
-usermod -aG wheel liveuser > /dev/null
-
-# Remove root password lock
-passwd -d root > /dev/null
-
-# turn off firstboot for livecd boots
-systemctl --no-reload disable firstboot-text.service 2> /dev/null || :
-systemctl --no-reload disable firstboot-graphical.service 2> /dev/null || :
-systemctl stop firstboot-text.service 2> /dev/null || :
-systemctl stop firstboot-graphical.service 2> /dev/null || :
-
-# don't use prelink on a running live image
-sed -i 's/PRELINKING=yes/PRELINKING=no/' /etc/sysconfig/prelink &>/dev/null || :
-
-# turn off mdmonitor by default
-systemctl --no-reload disable mdmonitor.service 2> /dev/null || :
-systemctl --no-reload disable mdmonitor-takeover.service 2> /dev/null || :
-systemctl stop mdmonitor.service 2> /dev/null || :
-systemctl stop mdmonitor-takeover.service 2> /dev/null || :
-
-# don't start cron/at as they tend to spawn things which are
-# disk intensive that are painful on a live image
-systemctl --no-reload disable crond.service 2> /dev/null || :
-systemctl --no-reload disable atd.service 2> /dev/null || :
-systemctl stop crond.service 2> /dev/null || :
-systemctl stop atd.service 2> /dev/null || :
-
-# turn off abrtd on a live image
-systemctl --no-reload disable abrtd.service 2> /dev/null || :
-systemctl stop abrtd.service 2> /dev/null || :
-
-# Don't sync the system clock when running live (RHBZ #1018162)
-sed -i 's/rtcsync//' /etc/chrony.conf
-
-# Mark things as configured
-touch /.liveimg-configured
-
-# add static hostname to work around xauth bug
-# https://bugzilla.redhat.com/show_bug.cgi?id=679486
-# the hostname must be something else than 'localhost'
-# https://bugzilla.redhat.com/show_bug.cgi?id=1370222
-hostnamectl set-hostname "localhost-live"
-
-EOF
-
-# bah, hal starts way too late
-cat > /etc/rc.d/init.d/livesys-late << EOF
-#!/bin/bash
-#
-# live: Late init script for live image
-#
-# chkconfig: 345 99 01
-# description: Late init script for live image.
-
-. /etc/init.d/functions
-
-if ! strstr "\`cat /proc/cmdline\`" rd.live.image || [ "\$1" != "start" ] || [ -e /.liveimg-late-configured ] ; then
-    exit 0
-fi
-
-exists() {
-    which \$1 >/dev/null 2>&1 || return
-    \$*
-}
-
-touch /.liveimg-late-configured
-
-# read some variables out of /proc/cmdline
-for o in \`cat /proc/cmdline\` ; do
-    case \$o in
-    ks=*)
-        ks="--kickstart=\${o#ks=}"
-        ;;
-    xdriver=*)
-        xdriver="\${o#xdriver=}"
-        ;;
-    esac
-done
-
-# if liveinst or textinst is given, start anaconda
-if strstr "\`cat /proc/cmdline\`" liveinst ; then
-   plymouth --quit
-   /usr/sbin/liveinst \$ks
-fi
-if strstr "\`cat /proc/cmdline\`" textinst ; then
-   plymouth --quit
-   /usr/sbin/liveinst --text \$ks
-fi
-
-# configure X, allowing user to override xdriver
-if [ -n "\$xdriver" ]; then
-   cat > /etc/X11/xorg.conf.d/00-xdriver.conf <<FOE
-Section "Device"
-	Identifier	"Videocard0"
-	Driver	"\$xdriver"
-EndSection
-FOE
-fi
-
-EOF
-
-chmod 755 /etc/rc.d/init.d/livesys
-/sbin/restorecon /etc/rc.d/init.d/livesys
-/sbin/chkconfig --add livesys
-
-chmod 755 /etc/rc.d/init.d/livesys-late
-/sbin/restorecon /etc/rc.d/init.d/livesys-late
-/sbin/chkconfig --add livesys-late
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
 
 # enable tmpfs for /tmp
 systemctl enable tmp.mount
@@ -306,7 +95,7 @@ rm -f /boot/*-rescue*
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794
-/sbin/chkconfig network off
+systemctl disable network
 
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
@@ -314,17 +103,3 @@ touch /etc/machine-id
 
 %end
 
-
-%post --nochroot
-# For livecd-creator builds only (lorax/livemedia-creator handles this directly)
-if [ -n "$LIVE_ROOT" ]; then
-    cp "$INSTALL_ROOT"/usr/share/licenses/*-release-common/* "$LIVE_ROOT/"
-
-    # only installed on x86, x86_64
-    if [ -f /usr/bin/livecd-iso-to-disk ]; then
-        mkdir -p "$LIVE_ROOT/LiveOS"
-        cp /usr/bin/livecd-iso-to-disk "$LIVE_ROOT/LiveOS"
-    fi
-fi
-
-%end

--- a/ks/fedora-mate-common.ks
+++ b/ks/fedora-mate-common.ks
@@ -1,0 +1,53 @@
+%packages
+# install env-group to resolve RhBug:1891500
+@^mate-desktop-environment
+
+fedora-release-matecompiz
+compiz
+compiz-plugins-main
+compiz-plugins-extra
+compiz-manager
+compizconfig-python
+compiz-plugins-experimental
+libcompizconfig
+compiz-plugins-main
+ccsm
+simple-ccsm
+emerald-themes
+emerald
+fusion-icon
+
+# blacklist applications which breaks mate-desktop
+-audacious
+
+# office
+@libreoffice
+
+# dsl tools
+rp-pppoe
+
+# FIXME; apparently the glibc maintainers dislike this, but it got put into the
+# desktop image at some point.  We won't touch this one for now.
+nss-mdns
+
+# Drop things for size
+-@3d-printing
+-@admin-tools
+-brasero
+-fedora-icon-theme
+-gnome-icon-theme
+-gnome-icon-theme-symbolic
+-gnome-logs
+-gnome-software
+-gnome-user-docs
+
+-@mate-applications
+
+# Help and art can be big, too
+-gnome-user-docs
+-evolution-help
+
+# Legacy cmdline things we don't want
+-telnet
+
+%end

--- a/ks/repos.ks
+++ b/ks/repos.ks
@@ -3,9 +3,9 @@ repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?rep
 repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f42&arch=x86_64
 url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-42&arch=x86_64
 #rpm fusion repos
-repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-42&arch=x86_64
-repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-42&arch=x86_64
-repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-42&arch=$basearch
-repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-42&arch=$basearch
+repo --name=rpmfusion-free --mirrorlist=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-42&arch=x86_64
+repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-released-42&arch=x86_64
+repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-42&arch=x86_64
+repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/metalink?repo=nonfree-fedora-updates-released-42&arch=x86_64
 #vojtux repo
 repo --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-42-x86_64/

--- a/ks/repos.ks
+++ b/ks/repos.ks
@@ -1,11 +1,11 @@
 # add repositories as sources of packages
-repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-41&arch=x86_64
-repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f41&arch=x86_64
-url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-41&arch=x86_64
+repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-42&arch=x86_64
+repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f42&arch=x86_64
+url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-42&arch=x86_64
 #rpm fusion repos
-repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-41&arch=x86_64
-repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-41&arch=x86_64
-repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-41&arch=$basearch
-repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-41&arch=$basearch
+repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-42&arch=x86_64
+repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-42&arch=x86_64
+repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-42&arch=$basearch
+repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-42&arch=$basearch
 #vojtux repo
-repo --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-41-x86_64/
+repo --name=Copr-repo-for-vojtux-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/vojtux-apps/fedora-42-x86_64/

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -79,6 +79,13 @@ pandoc
 brltty-xw
 %end
 
+# copied from fedora-live-mate-compiz.ks
+%post
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="mate"/' /etc/sysconfig/livesys
+
+%end
+
 %post
 # configure temporary dns
 cat >> /etc/resolv.conf << EOM
@@ -86,46 +93,6 @@ nameserver 8.8.8.8
 nameserver 8.8.4.4
 EOM
 
-cat >> /etc/rc.d/init.d/livesys << EOF
-
-
-# make the installer show up
-if [ -f /usr/share/applications/liveinst.desktop ]; then
-  # Show harddisk install in shell dash
-  sed -i -e 's/NoDisplay=true/NoDisplay=false/' /usr/share/applications/liveinst.desktop ""
-fi
-mkdir /home/liveuser/Desktop
-usermod -a -G brlapi liveuser
-cp /usr/share/applications/liveinst.desktop /home/liveuser/Desktop
-
-# and mark it as executable
-chmod +x /home/liveuser/Desktop/liveinst.desktop
-
-# rebuild schema cache with any overrides we installed
-glib-compile-schemas /usr/share/glib-2.0/schemas
-
-# set up lightdm autologin
-sed -i 's/^#autologin-user=.*/autologin-user=liveuser/' /etc/lightdm/lightdm.conf
-sed -i 's/^#autologin-user-timeout=.*/autologin-user-timeout=0/' /etc/lightdm/lightdm.conf
-#sed -i 's/^#show-language-selector=.*/show-language-selector=true/' /etc/lightdm/lightdm-gtk-greeter.conf
-
-# set MATE as default session, otherwise login will fail
-sed -i 's/^#user-session=.*/user-session=mate/' /etc/lightdm/lightdm.conf
-
-# Turn off PackageKit-command-not-found while uninstalled
-if [ -f /etc/PackageKit/CommandNotFound.conf ]; then
-  sed -i -e 's/^SoftwareSourceSearch=true/SoftwareSourceSearch=false/' /etc/PackageKit/CommandNotFound.conf
-fi
-
-# no updater applet in live environment
-rm -f /etc/xdg/autostart/org.mageia.dnfdragora-updater.desktop
-
-# make sure to set the right permissions and selinux contexts
-chown -R liveuser:liveuser /home/liveuser/
-restorecon -R /home/liveuser/
-
-
-EOF
 
 #rpm fusion keys
 echo "== RPM Fusion Free: Base section =="

--- a/ks/vojtux_common.ks
+++ b/ks/vojtux_common.ks
@@ -1,5 +1,6 @@
 %include fedora-live-base.ks
 %include repos.ks
+%include fedora-mate-common.ks
 
 selinux --disabled
 
@@ -12,47 +13,6 @@ services --enabled="chronyd,brltty"
 part / --size 10240 --fstype ext4
 
 %packages
-@mate
-@desktop-accessibility
-compiz
-compiz-plugins-main
-compiz-plugins-extra
-compiz-manager
-compizconfig-python
-compiz-plugins-experimental
-libcompizconfig
-compiz-plugins-main
-ccsm
-simple-ccsm
-emerald-themes
-emerald
-fusion-icon
-@networkmanager-submodules
-
-# some apps from mate-applications
-caja-actions
-mate-disk-usage-analyzer
-
-# office
-@libreoffice
-
-# dsl tools
-rp-pppoe
-
-# Drop things for size
--@3d-printing
--fedora-icon-theme
--gnome-icon-theme
--gnome-icon-theme-symbolic
--gnome-software
--gnome-user-docs
-
--mate-icon-theme-faenza
-
-# Help and art can be big, too
--gnome-user-docs
--evolution-help
-
 #customizations for Vojtux
 
 #additional software for Vojtux

--- a/ks/vojtux_en.ks
+++ b/ks/vojtux_en.ks
@@ -13,12 +13,6 @@ vojtux-docs-en
 %end
 
 %post
-cat > /etc/dconf/db/local.d/03-keybindings <<- EOM
-
-EOM
-
-dconf update
-
 #apply Vojtux customizations
 git clone https://github.com/vojtapolasek/Vojtux.git
 cd vojtux/downloads

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -1,5 +1,6 @@
 /TC1:
     summary: TC11 - Start Firefox via special shortcut
+    duration: 2h
     test: ssh -o StrictHostKeyChecking=no liveuser@vojtux "cd /home/liveuser/vojtux/tests && sudo ./runtest.sh TC11"
 
 #/TC2:

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -52,7 +52,8 @@ if [ ! -e /tmp/automation_setup_done ]; then
 fi
 
 sudo chmod 755 /home/liveuser/
-
+  systemctl start lightdm.service
+  sleep 5
 # Run the test we are asked to run!
 sudo -u test dogtail-run-headless-next --dm lightdm "behave -t $1 -k -f html-pretty -o $TEST_REPORT_FILE -f plain"; rc=$?
 

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -46,6 +46,7 @@ if [ ! -e /tmp/automation_setup_done ]; then
   sudo -u test dbus-launch gsettings set org.gnome.desktop.interface toolkit-accessibility true
   # some grace time 
   sleep 5
+  systemctl daemon-reload
   # Make the setup only once.
   touch /tmp/automation_setup_done
 fi

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -55,7 +55,7 @@ sudo chmod 755 /home/liveuser/
   systemctl start lightdm.service
   sleep 5
 # Run the test we are asked to run!
-sudo -u test dogtail-run-headless-next --dm lightdm "behave -t $1 -k -f html-pretty -o $TEST_REPORT_FILE -f plain"; rc=$?
+sudo -u test dogtail-run-headless-next --dm lightdm "behave -t $1 -f html-pretty -o $TEST_REPORT_FILE -f plain"; rc=$?
 
 # Mark result FAIL or PASS depending on the test result.
 RESULT="FAIL"

--- a/tests/vojtux_provision/setup.sh
+++ b/tests/vojtux_provision/setup.sh
@@ -10,7 +10,7 @@ services --enabled "sshd"
 echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config
 %end
 EOM
-livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --ks vojtux.ks --tmp tmp/ --iso-name vojtux.iso --project vojtux
+livemedia-creator --make-iso --no-virt --iso-only  --anaconda-arg="--noselinux" --ks vojtux.ks --tmp tmp/ --iso-name vojtux.iso --project vojtux --timeout 30
 vojtux_iso_path=$(find . -name vojtux.iso)
 mv $vojtux_iso_path /var/lib/libvirt/images/vojtux.iso
 virsh net-define tests/vojtux_provision/vojtux_net.xml


### PR DESCRIPTION
Base Vojtux on Fedora 42.
Kickstart files are cleaned a lot.
See commits for more information.